### PR TITLE
Better German translation for signup page

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -88,13 +88,13 @@
     <!-- activity_post_call -->
     <string name="callsigns">Rufzeichen</string>
     <!-- activity_login -->
-    <string name="DAPscription2">DAPNET is an international amateur radio paging network developed by the Amateur
-        Radio Group at the RWTH Aachen University. In order to participate and use this app, you need to be a
-        valid amateur radio operator and have an account at hampager.de. If you do not have a an account yet, sign
-        up below for a new ticket with \"New DAPNET Account\" as the help topic.</string>
-    <string name="continue_without_signing_in">Continue without signing in</string>
-    <string name="action_sign_up">Anmelden</string>
-    <string name="action_sign_up_short">Anmelden</string>
+    <string name="DAPscription2">DAPNET ist ein internationales Amateurfunkrufnetz, das von der Amateurfunkgruppe der
+        Radio Group an der RWTH Aachen entwickelt wurde. Um teilzunehmen und diese App zu nutzen, müssen Sie ein
+        gültiger Funkamateur sein und einen Account bei hampager.de haben. Wenn Sie noch keinen Account haben, erstellen Sie
+        unten ein neues Ticket mit dem Hilfethema "Neuer DAPNET Zugang" an.</string>
+    <string name="continue_without_signing_in">Ohne Registrierung fortfahren</string>
+    <string name="action_sign_up">Registrieren</string>
+    <string name="action_sign_up_short">Registrieren</string>
     <!-- "FloatingActionButton" -->
     <string name="send_paging_message">\t\tNachricht senden</string>
     <!-- Navigation drawer -->


### PR DESCRIPTION
On the Signup page we have two problems:

1. Login and Signup are both Translated to "Anmelden". This PR changes the Signup string to "Registrieren"
2. There is a Text-block-introduction to DAPNET that is still in English. This PR provides a German translation to that. 