### PR TITLE
Fixes Issue 76: Crash on orientation change

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
         <activity
             android:name=".activites.MainActivity"
             android:label="@string/app_name"
+            android:screenOrientation="portrait"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
The App's main activity is obviously designed for portrait orientation. We can prevent the crash by limiting the activity to portrait mode.